### PR TITLE
WPGraphQL 2.0 Compatability

### DIFF
--- a/src/filter-exception.php
+++ b/src/filter-exception.php
@@ -18,16 +18,7 @@ class FilterException extends \Exception implements ClientAware {
 	 *
 	 * @return bool isSafe from ClientAware.
 	 */
-	public function isClientSafe() {
+	public function isClientSafe(): bool {
 		return true;
-	}
-
-	/**
-	 * Relay ClientAware fn.
-	 *
-	 * @return string category from ClientAware.
-	 */
-	public function getCategory() {
-		return 'wp-graphql-filter-query plugin';
 	}
 }


### PR DESCRIPTION
The error handling had a breaking change, this pull request updates to match the 2.0 behavior. Refer to [Issue #42 ](https://github.com/wpengine/wp-graphql-filter-query/issues/42)